### PR TITLE
$heading needs space when heading has child element

### DIFF
--- a/lib/simple_toc/version.rb
+++ b/lib/simple_toc/version.rb
@@ -1,3 +1,3 @@
 module SimpleToc
-  VERSION = "0.2.4"
+  VERSION = "0.3.0"
 end

--- a/vendor/assets/javascripts/simpleToc.js
+++ b/vendor/assets/javascripts/simpleToc.js
@@ -9,7 +9,7 @@
         return prefix + '-' + i;
       },
       headerText: function($heading) {
-        return $heading.text();
+        return $heading.replaceWith( $heading.html().replace(/<\/?[^>]+>/gi, ' '))
       },
       listClass: function(i, heading, $heading, prefix) {
         return prefix + '-' + $heading[0].tagName.toLowerCase();

--- a/vendor/assets/javascripts/simpleToc.js
+++ b/vendor/assets/javascripts/simpleToc.js
@@ -9,7 +9,7 @@
         return prefix + '-' + i;
       },
       headerText: function($heading) {
-        return $heading.replaceWith( $heading.html().replace(/<\/?[^>]+>/gi, ' '))
+        return $heading.html().replace(/<\/?[^>]+>/gi, ' ').replace(/^\s/g, '')
       },
       listClass: function(i, heading, $heading, prefix) {
         return prefix + '-' + $heading[0].tagName.toLowerCase();
@@ -34,7 +34,8 @@
         headers.each(function(i, header) {
           var $h = $(header);
           var anchorName = plugin.settings.anchorName(i, plugin.settings.prefix);
-          var headerText = plugin.settings.headerText($h).replace(/\s/g, "");
+          console.log(plugin.settings.headerText($h))
+          var headerText = plugin.settings.headerText($h)
           if (headerText.length <= 0) {
             return true;
           }


### PR DESCRIPTION
@miraoto hi miraoto 
thank you for nice toc

I have a  problem when I treat $heading has child element ( something like this `<h3><span>contributer</span>ohayoukenchan</h3>`

result is bellow

`contributerohayoukenchan`

I need `contributer ohayoukenchan`